### PR TITLE
Fix issue #178

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -22,12 +22,12 @@ import seedu.address.model.task.Task;
 
 public class AddTaskCommand extends Command {
 
-    public static final String COMMAND_WORD = "addtask";
+    public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_SUCCESS = "Added %1$d %2$s to Person: %3$s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Add to the task list of the person identified "
+            + ": Add a task to the task list of the person identified "
             + "by the index number used in the last person listing.\n"
             + "Parameters: INDEX (must be a positive integer less than or equal to " + Integer.MAX_VALUE + ")\n"
             + PREFIX_TASK_DESCRIPTION + " TASK_NAME "
@@ -35,7 +35,10 @@ public class AddTaskCommand extends Command {
             + "[" + PREFIX_TASK_TIME + " TASK_TIME] "
             + "[" + PREFIX_TASK_VENUE + " TASK_VENUE] \n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TASK_DESCRIPTION + " Likes to swim.";
+            + PREFIX_TASK_DESCRIPTION + " Meeting "
+            + PREFIX_TASK_DATE + " 2022-01-01 "
+            + PREFIX_TASK_TIME + " 13:29 "
+            + PREFIX_TASK_VENUE + " Board Room";
 
     public static final String DESCRIPTION = "Add to the task list of the person specified by INDEX";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -22,7 +22,7 @@ import seedu.address.model.task.Task;
 public class DeleteTaskCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Removed %1$d %2$s from %3$s";
-    public static final String COMMAND_WORD = "deletetask";
+    public static final String COMMAND_WORD = "rm";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the task, specified by the TASKINDEX, from person "
             + "identified by the index number used in the displayed person list.\n"

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -83,7 +83,7 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     private final Index targetTaskIndex;
-    private final EditTaskCommand.EditTaskDescriptor editTaskDescriptor;
+    private final EditTaskDescriptor editTaskDescriptor;
 
     /**
      * @param index of the person in the filtered person list to edit
@@ -92,7 +92,7 @@ public class EditCommand extends Command {
      * @param editTaskDescriptor details to edit the task with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor,
-                       Index targetTaskIndex, EditTaskCommand.EditTaskDescriptor editTaskDescriptor) {
+                       Index targetTaskIndex, EditTaskDescriptor editTaskDescriptor) {
         requireNonNull(index);
 
         this.index = index;
@@ -185,7 +185,7 @@ public class EditCommand extends Command {
                 updatedDescription, updatedisImportant);
     }
 
-    private static Task createEditedTask(Task taskToEdit, EditTaskCommand.EditTaskDescriptor editTaskDescriptor) {
+    private static Task createEditedTask(Task taskToEdit, EditTaskDescriptor editTaskDescriptor) {
         assert(taskToEdit != null);
 
         TaskName updatedName = editTaskDescriptor.getTaskName().orElse(taskToEdit.getTaskName());
@@ -357,6 +357,89 @@ public class EditCommand extends Command {
                     && getTags().equals(e.getTags())
                     && getTasks().equals(e.getTasks())
                     && getDescription().equals(e.getDescription());
+        }
+    }
+
+    /**
+     * Stores the details to edit the task with. Each non-empty field value will replace the
+     * corresponding field value of the task.
+     */
+    public static class EditTaskDescriptor {
+        private TaskName taskName;
+        private TaskDate taskDate;
+        private TaskTime taskTime;
+        private Venue taskVenue;
+
+        public EditTaskDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditTaskDescriptor(EditTaskDescriptor toCopy) {
+            setTaskName(toCopy.taskName);
+            setTaskDate(toCopy.taskDate);
+            setTaskTime(toCopy.taskTime);
+            setTaskVenue(toCopy.taskVenue);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(taskName, taskDate, taskTime, taskVenue);
+        }
+
+        public void setTaskName(TaskName taskName) {
+            this.taskName = taskName;
+        }
+
+        public Optional<TaskName> getTaskName() {
+            return Optional.ofNullable(taskName);
+        }
+
+        public void setTaskDate(TaskDate taskDate) {
+            this.taskDate = taskDate;
+        }
+
+        public Optional<TaskDate> getTaskDate() {
+            return Optional.ofNullable(taskDate);
+        }
+
+        public void setTaskTime(TaskTime taskTime) {
+            this.taskTime = taskTime;
+        }
+
+        public Optional<TaskTime> getTaskTime() {
+            return Optional.ofNullable(taskTime);
+        }
+
+        public void setTaskVenue(Venue venue) {
+            this.taskVenue = venue;
+        }
+
+        public Optional<Venue> getTaskVenue() {
+            return Optional.ofNullable(taskVenue);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditTaskDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditTaskDescriptor e = (EditTaskDescriptor) other;
+
+            return getTaskName().equals(e.getTaskName())
+                    && getTaskDate().equals(e.getTaskDate())
+                    && getTaskTime().equals(e.getTaskTime())
+                    && getTaskVenue().equals(e.getTaskVenue());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -86,18 +86,6 @@ public class HelpCommand extends Command {
                 commandResult = new CommandResult(HelpCommand.MESSAGE_USAGE);
                 break;
 
-            case AddTaskCommand.COMMAND_WORD:
-                commandResult = new CommandResult(AddTaskCommand.MESSAGE_USAGE);
-                break;
-
-            case DeleteTaskCommand.COMMAND_WORD:
-                commandResult = new CommandResult(DeleteTaskCommand.MESSAGE_USAGE);
-                break;
-
-            case EditTaskCommand.COMMAND_WORD:
-                commandResult = new CommandResult(EditTaskCommand.MESSAGE_USAGE);
-                break;
-
             case ViewTaskListCommand.COMMAND_WORD:
                 commandResult = new CommandResult(ViewTaskListCommand.MESSAGE_USAGE);
                 break;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,14 +7,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.DoneCommand;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -78,15 +78,6 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommandParser().parse(arguments);
 
-        case AddTaskCommand.COMMAND_WORD:
-            return new AddTaskCommandParser().parse(arguments);
-
-        case DeleteTaskCommand.COMMAND_WORD:
-            return new DeleteTaskCommandParser().parse(arguments);
-
-        case EditTaskCommand.COMMAND_WORD:
-            return new EditTaskCommandParser().parse(arguments);
-
         case ViewTaskListCommand.COMMAND_WORD:
             return new ViewTaskListCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.EditTaskCommand.EditTaskDescriptor;
+import seedu.address.logic.commands.EditCommand.EditTaskDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Task;

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -4,13 +4,10 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.DoneCommand;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -60,12 +60,6 @@ public class HelpCommandParser {
 
             case HelpCommand.COMMAND_WORD:
 
-            case AddTaskCommand.COMMAND_WORD:
-
-            case DeleteTaskCommand.COMMAND_WORD:
-
-            case EditTaskCommand.COMMAND_WORD:
-
             case ViewTaskListCommand.COMMAND_WORD:
 
             case DoneCommand.COMMAND_WORD:

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -38,7 +38,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_addTask() throws Exception {
-        String command = AddTaskCommand.COMMAND_WORD + " 1 " + PREFIX_TASK_DESCRIPTION + "blob ";
+        String command = AddCommand.COMMAND_WORD + " 1 " + PREFIX_TASK_DESCRIPTION + "blob ";
         String moreTask = PREFIX_TASK_DESCRIPTION + "blob2";
         assertTrue(parser.parseCommand(command) instanceof AddTaskCommand);
         assertTrue(parser.parseCommand(command + moreTask) instanceof AddTaskCommand);


### PR DESCRIPTION
`addtask`, `edittask`, and `deletetask` are no longer valid commands.

`edit` is now handled only in `EditCommand`. `EditTaskCommand` is not used except in tests, which will be modified later.

`AddTaskCommand` is still used since `add 1 -tn NewTask` issues a command to add task, distinct from `add -n Ben ....`. It would be better handled by the separate, internal `AddTaskCommand`, rather than having two cases of execution flow in `AddCommand`.
The same follows for `DeleteTaskCommand`.