### PR TITLE
Fix bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -31,7 +31,7 @@ to quickly navigate to the command of your choice.
 * [Deleting a person : `rm`](#deleting-a-person-rm)
 * [Listing all persons : `ls`](#listing-all-persons-ls)
 * [Sorting persons by name: `sort`](#sorting-persons-by-name-sort)
-* [Locating persons by name : `find`](#locating-persons-by-name-find)
+* [Locating persons by name : `find`](#locating-persons-find)
 * [Adding a task : `add`](#adding-a-task-add)
 * [Editing a task : `edit`](#editing-a-task-edit)
 * [Deleting a task : `rm`](#deleting-a-task-rm)

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -81,7 +81,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited() && argMultimap.getValue(PREFIX_TASK_INDEX).isEmpty()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
         if (argMultimap.getValue(PREFIX_TASK_INDEX).isPresent()) {

--- a/src/main/java/seedu/address/model/task/TaskTime.java
+++ b/src/main/java/seedu/address/model/task/TaskTime.java
@@ -44,7 +44,8 @@ public class TaskTime {
 
     @Override
     public String toString() {
-        return taskTime.format(DateTimeFormatter.ISO_LOCAL_TIME);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return taskTime.format(formatter);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -63,7 +63,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
Fix the following bugs:
- Time saved in wrong format, resulting in parse error when reloading file.
- Edit Command returning message to have at least one field to edit when only index and task time provided (No task index)
- UG broken link for Find command.